### PR TITLE
server.ts: fix location of errors with multiple ranges

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -913,27 +913,23 @@ function handleIdeDiagnostics (textDocument : TextDocument, response : IdeError 
 	response.forEach((err) => {
 		let diag : Diagnostic | undefined = undefined;
 		err.ranges.forEach ((rng) => {
-			if (rng.fname == "<input>") {
+			if (!diag) {
+				// First range for this error, construct the diagnostic message.
+				let maybe_fname = "";
+				if (rng.fname != "<input>")
+					maybe_fname = " (in file " + rng.fname + ")";
 				diag = {
 					severity: ideErrorLevelAsDiagnosticSeverity(err.level),
 					range: {
 						start: mkPosition(rng.beg),
 						end: mkPosition(rng.end)
 					},
-					message: err.message
+					message: err.message + maybe_fname
 				};
 			} else if (diag) {
+				// More ranges, just accumulate them into the message.
 				const seeAlso = "(See related location: " + rng.fname + ":" + rng.beg[0] + ":" + rng.beg[1] + ")";
 				diag.message = diag.message + "\n" + seeAlso;
-			} else {
-				diag = {
-					severity: ideErrorLevelAsDiagnosticSeverity(err.level),
-					range: {
-						start: mkPosition(rng.beg),
-						end: mkPosition(rng.end)
-					},
-					message: err.message + " (in file " + rng.fname + ")"
-				};
 			}
 		});
 		if (diag) {


### PR DESCRIPTION
The `rng.fname == <input>` condition will still be true the second time around, so we do not go into the second case and instead overwrite the diagnostic completely. Fix it by checking for `diag` being undefined.

---

Example file to reproduce:

```fstar
module X

let f (x : int{x == 12}) : int = x

let g = f (-10)
```
Before:
<img width="926" alt="image" src="https://user-images.githubusercontent.com/4195583/228063347-d46cca38-d897-4908-94cd-ee6b19244ae8.png">

After:
<img width="919" alt="image" src="https://user-images.githubusercontent.com/4195583/228063614-13dee91f-2ae8-4879-9a81-ff389378ba68.png">
