### PR TITLE
Mention setup for opam in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ https://github.com/artagnon/vsfstar
 
 An initial release v0.3.0 is available on the VSCode marketplace.
 
-You need to have a working F* installation, where `fstar.exe` is in your path
-and `fstar.exe --ide A.fst` should print the following protocol-info:
+You need to have a working F* installation, where `fstar.exe` and `z3` are in your path.
+If you have installed F* or Z3 using opam, make sure you start VS Code from inside the opam environment after running `eval $(opam env)`.
+If you are using WSL, the WSL plugin for VS Code will run your `bashrc`, and it is enough to put the `eval $(opam env)` there.
+(When only Z3 is missing, you will get a message like `ERROR: F* flycheck process exited with code 1`.)
 
-```
+The command `fstar.exe --ide A.fst` should print the following protocol-info:
+```json
 {"kind":"protocol-info","version":2,"features":["autocomplete","autocomplete/context","compute","compute/reify","compute/pure-subterms","describe-protocol","describe-repl","exit","lookup","lookup/context","lookup/documentation","lookup/definition","peek","pop","push","search","segment","vfs-add","tactic-ranges","interrupt","progress","full-buffer","format","restart-solver", "cancel"]}
 ```
 


### PR DESCRIPTION
It took me a while to get the extension to work.  I had `fstar.exe` in the default PATH, but `z3` was only installed via opam.  If you now happen to start VS Code outside the opam env, then F* can't find the Z3 executable and you get the uninformative error message `ERROR: F* flycheck process exited with code 1`.

This PR adds a couple of sentences to the README reminding the user to start VS Code from inside the opam env, as well as mentioning what happens when Z3 is missing.

FWIW, extensions for other languages often modify the path to make this a bit smoother.  The Python extension automatically picks up venvs and offers to start Python from there (i.e., the equivalent of running `opam exec -- fstar.exe`).  And our Lean extension adds `~/.elan/bin` to the path (where the default installation instructions place Lean).

cc @mtzguido @aseemr I hear you're using VS Code with WSL as well, do you have any issues or suggestions you'd like to add here?