### PR TITLE
Solve "file not found" errors when using hints of modules in subdirectories

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1158,8 +1158,7 @@ async function refreshDocumentState(textDocument : TextDocument) {
 
 	// Construct the options for fstar.exe
 	const filePath = URI.parse(textDocument.uri);
-	const filename = path.basename(filePath.fsPath);
-	const options = ["--ide", filename];
+	const options = ["--ide", filePath.fsPath];
 	if (fstarConfig.options) {
 		fstarConfig.options.forEach((opt) => { options.push(opt); });
 	}
@@ -1214,7 +1213,7 @@ async function refreshDocumentState(textDocument : TextDocument) {
 	fstar_lax_ide.stderr.on('data', (data) => { console.error("fstar lax stderr: " +data); });
 	
 	// Send the initial dummy vfs-add request to the fstar processes
-	const vfs_add : VfsAdd = {"query":"vfs-add","args":{"filename":null,"contents":textDocument.getText()}};
+	const vfs_add : VfsAdd = {"query":"vfs-add","args":{"filename":filePath.fsPath,"contents":textDocument.getText()}};
 	sendRequestForDocument(textDocument, vfs_add);
 	sendRequestForDocument(textDocument, vfs_add, 'lax');
 }


### PR DESCRIPTION
This fix explicitly passes the full path of the module being added to the running F* process rather than just the filename (or leaving it up to interpretation. Specifically `--ide [filename]` is replaced with `--ide [module_path]` and the query to the F* process `vfs-add` now sends the filename as `[module_path]` rather than `null`.

This solves an issue when modules are defined in subdirectories of the workspace's root directory that cross-reference each other with hints/checked file directories in the root directory:

```
workspace_root/
├─ dir_A/
│  ├─ A.fst
├─ dir_B/
│  ├─ B.fst
├─ Project.fst.config.json
├─ .hints/
├─ .out/
├─ .cache/
```

The issue arises when `A.fst` references `B.fst`, and a separate Makefile generates the corresponding `*.checked` and `*.hints` files into the `.hints` and `.cache` directories. If the option `--hint_dir` and `--cache_dir` are *not* passed to the assistant, the verification runs fine but it fails to find both the `.checked` and `.hints` files. This is annoying when it causes a restart of the assistant's F* process to take a very long time because it needs to re-verify the entire file again.

Moreover, when passing the `--hint_dir .hints` option through `Project.fst.config.json` the assistant crashes outright. Because the assistant doesn't pass the full path with `vfs-add` or `--ide`, it will instead look for these files in the root directory: i.e. `workspace_root/A.fst` rather than its subdirectory. This causes the assistant to crash.

This fix resolves this, though perhaps not scanning relative to the root directory but relative to the module being parsed (for the options) would be better.