### PR TITLE
Substitute environment variables in config file

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1061,10 +1061,13 @@ let hasWorkspaceFolderCapability = false;
 let hasDiagnosticRelatedInformationCapability = false;
 let supportsFullBuffer = true;
 
-function parseConfigFile(configFile: string) : FStarConfig {
-	const contents = fs.readFileSync(configFile, 'utf8');
-	const config = JSON.parse(contents);
-	return config;
+function parseConfigFile(configFile) {
+    const contents = fs.readFileSync(configFile, 'utf8');
+    const config = JSON.parse(contents, (key, value) =>
+        typeof value === "string"
+            ? value.replace(/\$([A-Z_]+[A-Z0-9_]*)|\${([A-Z0-9_]*)}/ig, (_, a, b) => process.env[a || b])
+            : value);
+    return config;
 }
 
 // Initialization of the LSP server: Called once when the workspace is opened


### PR DESCRIPTION
Currently the local configuration file (in the workspace's root directory) does not substitute/interpret environment variables. However, I would like to be able to pass environment variables through the configuration file. Consider the following situation:

```Project/
├─ Sub_1/
│  ├─ Sub_1.fst
│  ├─ Sub_1.fst.config.json
├─ Sub_2/
│  ├─ Sub_2.fst
│  ├─ Sub_2.fst.config.json
```

If sub-projects 1 and 2 want to include things from one another but have to remain separate (for whatever reason) this would require hardcoding the absolute or relative path in the configuration file. However, this could be undesirable if e.g. multiple contributors collaborate, or the relative path between the projects is not constant. If, however, the paths are available in `SUB_1_HOME` and `SUB_2_HOME`, using these environment variables is convenient.