### PR TITLE
Handle fragmented messages from F* by storing fragments in a buffer

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -810,18 +810,67 @@ function sendClearDiagnostics(msg: ClearDiagnosticsMessage) {
 	connection.sendNotification('fstar-vscode-assistant/clearDiagnostics', msg);
 }
 
- ///////////////////////////////////////////////////////////////////////////////////
- // Handling responses from the F* IDE protocol
- ///////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////
+// Handling responses from the F* IDE protocol
+///////////////////////////////////////////////////////////////////////////////////
 
- // Event handler for stdout on fstar_ide
- function handleFStarResponseForDocument(textDocument: TextDocument, data:string, lax:boolean) {
-	if (configurationSettings.debug) {
-		console.log("<<< " + (lax? "lax" : "") + "uri:<" +textDocument.uri + ">:" +data);
+// All IDE messages are expected to be valid JSON objects
+function is_valid_ide_message(entry: string): boolean {
+	try {
+		JSON.parse(entry);
+		return true;
 	}
-	const lines = data.toString().split('\n');
-	lines.forEach(line => { handleOneResponseForDocument(textDocument, line, lax);  });
+	catch(err) {
+		return false;
+	}
 }
+
+// Event handler for stdout on fstar_ide. Created as a closure to keep the
+// buffer scoped only to this function. The factory function exists to make
+// unit-testing easier (creating a new function is like resetting the closure
+// state).
+const handleFStarResponseForDocumentFactory: () => ((textDocument: TextDocument, data:string, lax:boolean) => void) = function () {
+	// Stateful buffer to store partial messages. Messages appear to be fragmented
+	// into 8192 byte chunks if they exceed this size.
+	let buffer = "";
+
+	return function(textDocument: TextDocument, data:string, lax:boolean) {
+		if (configurationSettings.debug) {
+			console.log("<<< " + (lax? "lax" : "") + "uri:<" +textDocument.uri + ">:" +data);
+		}
+		const lines = data.toString().split('\n');
+
+		const valid_lines: string[] = [];
+		for (const line of lines) {
+			if (is_valid_ide_message(line)) {
+				// We assume that fragmented messages will always be delivered
+				// sequentially. Because of this, receiving a non-fragmented
+				// message while the buffer is non-empty results in the buffer
+				// being discarded (since we assume that some error occured).
+				if (buffer !== "") {
+					console.error("Partially buffered message discarded: " + buffer);
+				}
+				buffer = "";
+				valid_lines.push(line);
+			} else {
+				// We assume that invalid messages are just message fragments.
+				// We therefore add this fragment to the buffer until the full
+				// message is received.
+				buffer += line;
+				// The message fragment we received may be the last fragment
+				// needed to complete a message. We therefore check here to see
+				// if the buffer constitutes a valid message.
+				if (is_valid_ide_message(buffer)) {
+					valid_lines.push(buffer);
+					buffer = "";
+				}
+			}
+		}
+
+		valid_lines.forEach(line => { handleOneResponseForDocument(textDocument, line, lax); });
+	};
+};
+const handleFStarResponseForDocument: (textDocument: TextDocument, data:string, lax:boolean) => void = handleFStarResponseForDocumentFactory();
 
 // Main event dispatch for IDE responses
 function handleOneResponseForDocument(textDocument: TextDocument, data:string, lax: boolean) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -814,8 +814,8 @@ function sendClearDiagnostics(msg: ClearDiagnosticsMessage) {
 // Handling responses from the F* IDE protocol
 ///////////////////////////////////////////////////////////////////////////////////
 
-// All IDE messages are expected to be valid JSON objects
-function is_valid_ide_message(entry: string): boolean {
+// All messages from F* are expected to be valid JSON objects
+function is_valid_fstar_message(entry: string): boolean {
 	try {
 		JSON.parse(entry);
 		return true;
@@ -842,7 +842,7 @@ const handleFStarResponseForDocumentFactory: () => ((textDocument: TextDocument,
 
 		const valid_lines: string[] = [];
 		for (const line of lines) {
-			if (is_valid_ide_message(line)) {
+			if (is_valid_fstar_message(line)) {
 				// We assume that fragmented messages will always be delivered
 				// sequentially. Because of this, receiving a non-fragmented
 				// message while the buffer is non-empty results in the buffer
@@ -860,7 +860,7 @@ const handleFStarResponseForDocumentFactory: () => ((textDocument: TextDocument,
 				// The message fragment we received may be the last fragment
 				// needed to complete a message. We therefore check here to see
 				// if the buffer constitutes a valid message.
-				if (is_valid_ide_message(buffer)) {
+				if (is_valid_fstar_message(buffer)) {
 					valid_lines.push(buffer);
 					buffer = "";
 				}


### PR DESCRIPTION
Resolves #18.

Messages from F* larger than 8192 bytes seem to get fragmented into multiple messages when read by the language server. This typically results in invalid JSON messages when this fragmentation occurs. This PR supports re-assembly of fragmented messages under the assumptions that:
- fragmented messages will always be delivered sequentially and in-order
- messages that are not valid JSON are always fragmented messages

I'm opening this as a draft PR since I'd like to add unit tests for my changes, but am running into some difficulties that might be best addressed by refactoring (e.g. loading the server module that contains the handlers currently requires a connection for the server).