### PR TITLE
Read configuration from `make File.fst-in`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 npm-debug.log
 Thumbs.db
-*/node_modules/
+node_modules/
 */out/
 */.vs/
 tsconfig.lsif.json

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -446,7 +446,7 @@ export class Server {
 	}
 
 	async refreshDocumentState(textDocument: TextDocument) {
-		const fstar = FStar.fromInferredConfig(textDocument, this.workspaceFolders, this.connection, this.configurationSettings);
+		const fstar = await FStar.fromInferredConfig(textDocument, this.workspaceFolders, this.connection, this.configurationSettings);
 		// Failed to start F*
 		if (!fstar) { return; }
 
@@ -677,12 +677,12 @@ export class Server {
 		return [];
 	}
 
-	private onDocumentRangeFormatting(formatParams: DocumentRangeFormattingParams) {
+	private async onDocumentRangeFormatting(formatParams: DocumentRangeFormattingParams) {
 		const textDoc = this.getDocument(formatParams.textDocument.uri);
 		if (!textDoc) { return []; }
 		const text = textDoc.getText(formatParams.range);
 		// call fstar.exe synchronously to format the text
-		const fstarConfig = FStar.getFStarConfig(textDoc, this.workspaceFolders, this.connection, this.configurationSettings);
+		const fstarConfig = await FStar.getFStarConfig(textDoc, this.workspaceFolders, this.connection, this.configurationSettings);
 		const format_query = {
 			"query-id": "1",
 			query: "format",

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -8,6 +8,7 @@ import path = require('path');
 import { pathToFileURL } from 'url';
 
 import * as fs from 'fs';
+import * as util from 'util';
 
 import { Server } from './server';
 
@@ -55,9 +56,9 @@ export function qualifyFilename(fname: string, textdocUri: string, server: Serve
 
 // Checks if filePath is includes in the cone rooted at dirPath
 // Used to check if a file is in the workspace
-export function checkFileInDirectory(dirPath: string, filePath: string): boolean {
+export async function checkFileInDirectory(dirPath: string, filePath: string): Promise<boolean> {
 	// Check if dirPath is a directory using fs.stat()
-	const stats = fs.statSync(dirPath);
+	const stats = await util.promisify(fs.stat)(dirPath);
 	if (!stats || !stats.isDirectory()) {
 		//console.log(dirPath + ' is not a directory');
 		return false;
@@ -80,24 +81,10 @@ export function checkFileInDirectory(dirPath: string, filePath: string): boolean
 // Finds all files in a folder whose name has `extension` as a suffix
 // Returns an array of absolute paths of the files
 // Used to find all config files in the workspace
-export function findFilesByExtension(folderPath: string, extension: string) {
-	// Read the folder contents using fs.readdir()
-	const matches: string[] = [];
-	const files = fs.readdirSync(folderPath);
-	if (!files) {
-		console.error("No files found in " + folderPath);
-		return [];
-	}
-	// Loop over the files
-	for (const file of files) {
-		// console.log("Checking file " + file + " for extension " + extension);
-		if (file.endsWith(extension)) {
-			// console.log("Found config file " + file);
-			// absolute path of file is folderPath + file
-			matches.push(path.join(folderPath, file));
-		}
-	}
-	return matches;
+export async function findFilesByExtension(folderPath: string, extension: string): Promise<string[]> {
+	return (await util.promisify(fs.readdir)(folderPath))
+		.filter(file => file.endsWith(extension))
+		.map(file => path.join(folderPath, file));
 }
 
 export function getEnclosingDirectories(filePath: string): string[] {


### PR DESCRIPTION
The make target `File.fst-in` is a standard way to obtain the F* command-line flags necessary to build `File.fst`.  This PR adds support to the LSP server to read the configuration from `make File.fst-in` if there is no `.fst.config.json` file.

(Running `make` can potentially take quite some time, so I've made the whole configuration loading code async.)

@nikswamy I think you have something similar in your emacs config.  Does this look right?  If there's a file `lib/foo/Bar.fst`, then we run `make Bar.fst-in` the `lib/foo` directory and then split the output by spaces.  Are there any options we'd need to filter out?