### PR TITLE
Do not autoclose single quotes

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -16,8 +16,7 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
+        ["\"", "\""]
     ],
     // symbols that can be used to surround a selection
     "surroundingPairs": [


### PR DESCRIPTION
Single quotes are more common for the prime symbol rather than for character literals