### PR TITLE
Revise include path

### DIFF
--- a/lspserver/src/fstar.ts
+++ b/lspserver/src/fstar.ts
@@ -61,6 +61,10 @@ export class FStar {
 		if (config.include_dirs) {
 			config.include_dirs.forEach((dir) => { options.push("--include"); options.push(dir); });
 		}
+		if (!config.include_dirs || config.include_dirs.length === 0) {
+			options.push("--include");
+			options.push(path.dirname(filePath));
+		}
 		if (!config.fstar_exe) {
 			config.fstar_exe = "fstar.exe";
 		}


### PR DESCRIPTION
In many cases, we have config files that do not specify any include directories, and then launch the extension on `path/to/some/file/A.fst`. If `A.fst` refers to `B.fst` in the same directory, then this fails, since the include path is empty.

This patch adds `path/to/some/file` to the include path in case the include_dirs in the config file is empty.

This means, for instance, that you can launch the extension on, say, fstar/examples/data_structures/LowStar.Lens.Tuple2.fst, and it just works ... whereas previously, it would fail to fine LowStar.Lens.Buffer.fst in the same directory


