### PR TITLE
Close pipe before killing F*

### DIFF
--- a/lspserver/src/fstar_connection.ts
+++ b/lspserver/src/fstar_connection.ts
@@ -61,6 +61,7 @@ export class FStarConnection {
 
 	// Kills the F* process and closes the connection
 	close() {
+		this.fstar.proc.stdin?.end();
 		this.fstar.proc.kill();
 	}
 


### PR DESCRIPTION
The F* IDE mode will not die when a SIGINT is received. We need to close the pipe to signal no more data will be written for it to gracefully exit.

This is easily reproducible (before this patch) by opening a file, starting F*, and then closing the file. The F* process remains alive, eating up RAM.