### PR TITLE
Only compare basenames to check if F* reported filename matches current doc

### DIFF
--- a/lspserver/src/fstar_connection.ts
+++ b/lspserver/src/fstar_connection.ts
@@ -53,7 +53,7 @@ export class FStarConnection {
 	}
 
 	public fnameMatchesCurrentFile (fname:string, textdocUri: string) {
-		return ((this.fstar.fstarIdeVersion < 3 && fname === "<input>") || fname === path.basename(textdocUri));
+		return ((this.fstar.fstarIdeVersion < 3 && fname === "<input>") || path.basename(fname) === path.basename(textdocUri));
 	}
 
 	// Attempts to spawn an F* process, using the given configuration and


### PR DESCRIPTION
Previously, we would fail to resolve things like "fname":"ide/emacs/FlyDeps.fst" to the current file