### PR TITLE
Use the configured fstar.exe for --read_checked_file and --read_krml_…

### DIFF
--- a/extension/src/binaryeditors.ts
+++ b/extension/src/binaryeditors.ts
@@ -7,6 +7,8 @@ import { CancellationToken, Command, CustomDocument, CustomDocumentOpenContext, 
 import * as cp from 'child_process';
 import * as util from 'util';
 import { escape } from 'html-escaper';
+import { LanguageClient } from 'vscode-languageclient/node';
+import { getFStarExeRequest } from './fstarLspExtensions';
 
 class CommandOutputDocument implements CustomDocument {
 	constructor(public uri: Uri, public cmd: string, public stdout: string, public stderr: string) {}
@@ -36,8 +38,9 @@ ${escape(this.stdout)}
 }
 
 abstract class CommandOutputProvider implements CustomReadonlyEditorProvider<CommandOutputDocument> {
+	constructor(protected client: LanguageClient) {}
 	async openCustomDocument(uri: Uri): Promise<CommandOutputDocument> {
-		const cmd = this.getCommand(uri);
+		const cmd = await this.getCommand(uri);
 		const out = await util.promisify(cp.execFile)(cmd[0], cmd.slice(1), {
 			maxBuffer: 50*1024*1024, // allow up to 50 megabytes of output
 		});
@@ -46,12 +49,25 @@ abstract class CommandOutputProvider implements CustomReadonlyEditorProvider<Com
 	resolveCustomEditor(document: CommandOutputDocument, webviewPanel: WebviewPanel) {
 		webviewPanel.webview.html = document.toHtml();
 	}
-	abstract getCommand(uri: Uri): string[];
+	abstract getCommand(uri: Uri): Promise<string[]>;
+
+	protected async getFStarExe(uri: Uri): Promise<string> {
+		try {
+			const response = await this.client.sendRequest(getFStarExeRequest, { uri: uri.toString() });
+			return response.fstar_exe;
+		} catch {
+			return 'fstar.exe';
+		}
+	}
 }
 
 export class CheckedFileEditorProvider extends CommandOutputProvider {
-	getCommand(uri: Uri): string[] { return ['fstar.exe', '--read_checked_file', uri.fsPath]; }
+	async getCommand(uri: Uri): Promise<string[]> {
+		return [await this.getFStarExe(uri), '--read_checked_file', uri.fsPath];
+	}
 }
 export class KrmlFileEditorProvider extends CommandOutputProvider {
-	getCommand(uri: Uri): string[] { return ['fstar.exe', '--read_krml_file', uri.fsPath]; }
+	async getCommand(uri: Uri): Promise<string[]> {
+		return [await this.getFStarExe(uri), '--read_krml_file', uri.fsPath];
+	}
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -219,8 +219,8 @@ export async function activate(context: ExtensionContext) {
 		};
 	});
 
-	context.subscriptions.push(vscode.window.registerCustomEditorProvider('fstar.checked', new CheckedFileEditorProvider()));
-	context.subscriptions.push(vscode.window.registerCustomEditorProvider('fstar.krml', new KrmlFileEditorProvider()));
+	context.subscriptions.push(vscode.window.registerCustomEditorProvider('fstar.checked', new CheckedFileEditorProvider(client)));
+	context.subscriptions.push(vscode.window.registerCustomEditorProvider('fstar.krml', new KrmlFileEditorProvider(client)));
 
 	await client.start();
 }

--- a/lspserver/src/fstar.ts
+++ b/lspserver/src/fstar.ts
@@ -93,6 +93,18 @@ export class FStar {
 		return new FStar(proc, config, supportsFullBuffer, !!lax);
 	}
 
+	// Resolves the fstar_exe path from a config, applying the same logic as trySpawnFstar.
+	static resolveFStarExe(config: FStarConfig): string {
+		config.fstar_exe ??= "fstar.exe";
+		config.cwd ??= ".";
+		let fstar_exe_resolved = config.fstar_exe;
+		if (fstar_exe_resolved.includes(path.sep)) {
+			fstar_exe_resolved = path.resolve(config.cwd, fstar_exe_resolved);
+		}
+		fstar_exe_resolved = which.sync(fstar_exe_resolved);
+		return fstar_exe_resolved;
+	}
+
 	// Dynamically loads the FStarConfiguration for a given file `textDocument`
 	// before attempting to launch an instance of F*.
 	static async fromInferredConfig(filePath: string, workspaceFolders: WorkspaceFolder[], connection: Connection,

--- a/lspserver/src/fstarLspExtensions.ts
+++ b/lspserver/src/fstarLspExtensions.ts
@@ -56,4 +56,13 @@ export interface GetTranslatedFstResponse {
 export const getTranslatedFstRequest =
 	new RequestType<GetTranslatedFstParams, GetTranslatedFstResponse | undefined, undefined>('$/fstar/getTranslatedFst');
 
+export interface GetFStarExeParams {
+	uri: string;
+}
+export interface GetFStarExeResponse {
+	fstar_exe: string;
+}
+export const getFStarExeRequest =
+	new RequestType<GetFStarExeParams, GetFStarExeResponse, undefined>('$/fstar/getFStarExe');
+
 interface RegistrationParams {}

--- a/lspserver/src/server.ts
+++ b/lspserver/src/server.ts
@@ -11,7 +11,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI } from 'vscode-uri';
 import { defaultSettings, fstarVSCodeAssistantSettings } from './settings';
 import { FStar } from './fstar';
-import { statusNotification, killAndRestartSolverNotification, restartNotification, verifyToPositionNotification, killAllNotification, getTranslatedFstRequest, GetTranslatedFstParams, GetTranslatedFstResponse } from './fstarLspExtensions';
+import { statusNotification, killAndRestartSolverNotification, restartNotification, verifyToPositionNotification, killAllNotification, getTranslatedFstRequest, GetTranslatedFstParams, GetTranslatedFstResponse, getFStarExeRequest } from './fstarLspExtensions';
 import { DocumentState, DocumentStateEventHandlers, FStarDocumentState } from './documentState';
 import { CDocumentState } from './cDocumentState';
 
@@ -114,6 +114,12 @@ export class Server {
 			void this.getDocumentState(uri)?.killAndRestartSolver());
 		this.connection.onNotification(killAllNotification, () =>
 			this.onKillAllRequest());
+		this.connection.onRequest(getFStarExeRequest, async ({uri}) => {
+			const filePath = URI.parse(uri).fsPath;
+			const config = await FStar.getFStarConfig(filePath,
+				this.workspaceFolders, this.connection, this.configurationSettings);
+			return { fstar_exe: FStar.resolveFStarExe(config) };
+		});
 	}
 
 	run() {


### PR DESCRIPTION
…file

I noticed the extension was always using fstar.exe from the PATH to read checked and krml files, this makes it use the configured fstar.exe. This matters when the local fstar.exe is not on the PATH or is not binary-compatible with the one in it.

This was fully vibecoded, but seems reasonable to me.